### PR TITLE
Reworked entity _init and added resource class

### DIFF
--- a/characters/entity.gd
+++ b/characters/entity.gd
@@ -2,25 +2,14 @@ class_name Entity
 extends CharacterBody2D
 
 
-var health: Stat
-var speed: Stat
+var stats: EntityStats = null
+var health: Stat = null
+var speed: Stat = null
 
-
-func _init(
-		current_health: int,
-		max_health: int,
-		min_health: int,
-		current_speed: int,
-		max_speed: int,
-		min_speed: int
-		) -> void:
-	
-	health = Stat.new(current_health, max_health, min_health)
-	speed = Stat.new(current_speed, max_speed, min_speed)
-	
-
-func set_stat() -> void:
-	pass
+func _init(entity_type: String):
+	var entity_stats := load("res://characters/resources/%s.tres" % entity_type) as EntityStats
+	health = Stat.new(entity_stats.current_health, entity_stats.max_health, entity_stats.min_health)
+	speed = Stat.new(entity_stats.current_speed, entity_stats.max_speed, entity_stats.min_speed)
 	
 	
 func take_damage(damage: int) -> void:

--- a/characters/entity_stats.gd
+++ b/characters/entity_stats.gd
@@ -1,0 +1,10 @@
+extends Resource
+class_name EntityStats
+
+@export var current_health = 0
+@export var max_health = 0
+@export var min_health = 0
+
+@export var current_speed = 0
+@export var max_speed = 0
+@export var min_speed = 0

--- a/characters/resources/skeleton.tres
+++ b/characters/resources/skeleton.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="EntityStats" load_steps=2 format=3 uid="uid://psb3ve1x08lx"]
+
+[ext_resource type="Script" path="res://characters/entity_stats.gd" id="1_fy26o"]
+
+[resource]
+script = ExtResource("1_fy26o")
+current_health = 100
+max_health = 100
+min_health = 0
+current_speed = 50
+max_speed = 50
+min_speed = 0

--- a/characters/resources/test.tres
+++ b/characters/resources/test.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="EntityStats" load_steps=2 format=3 uid="uid://cjpck15kwvedm"]
+
+[ext_resource type="Script" path="res://characters/entity_stats.gd" id="1_t6vkk"]
+
+[resource]
+script = ExtResource("1_t6vkk")
+current_health = 1
+max_health = 1
+min_health = 1
+current_speed = 2
+max_speed = 2
+min_speed = 2

--- a/characters/stat.gd
+++ b/characters/stat.gd
@@ -12,15 +12,11 @@ var current_value: int:
 var min_value: int:
 	get:
 		return min_value
-	#set(new_value):
-	#	min_value = new_value 
-	#we don't need a setter for this probably
 
 var max_value: int:
 	get:
 		return max_value
 	set(new_value):
-		# second "new_value" can be replaced with some constant so we don't have OP characters 
 		max_value = clamp(new_value, min_value, new_value)
 
 func _init(current_val: int, max_val: int, min_val: int) -> void:

--- a/project.godot
+++ b/project.godot
@@ -35,6 +35,7 @@ folder_colors={
 "res://characters/": "gray",
 "res://characters/enemies/": "red",
 "res://characters/player/": "blue",
+"res://characters/resources/": "purple",
 "res://gui/": "gray",
 "res://levels/": "green",
 "res://music/": "pink",

--- a/tests/unit/test_entity.gd
+++ b/tests/unit/test_entity.gd
@@ -1,10 +1,10 @@
 extends GutTest
 
 func test_entity_innit_all_zeros():
-	var correct_health_values = [0, 0, 0]
-	var correct_speed_values = [0, 0, 0]
+	var correct_health_values = [1, 1, 1]
+	var correct_speed_values = [2, 2, 2]
 	
-	var innitialized_entity: Entity = Entity.new(0, 0, 0, 0, 0, 0)
+	var innitialized_entity: Entity = Entity.new("test")
 	
 	assert_eq([
 		innitialized_entity.health.current_value, 
@@ -16,10 +16,10 @@ func test_entity_innit_all_zeros():
 		innitialized_entity.speed.min_value], correct_speed_values)
 
 func test_entity_innit_with_values():
-	var correct_health_values = [5, 100, 0]
-	var correct_speed_values = [5, 10, 0]
+	var correct_health_values = [100, 100, 0]
+	var correct_speed_values = [50, 50, 0]
 	
-	var innitialized_entity: Entity = Entity.new(5, 100, 0, 5, 10, 0)
+	var innitialized_entity: Entity = Entity.new("skeleton")
 	
 	assert_eq([
 		innitialized_entity.health.current_value, 


### PR DESCRIPTION
Entity now works with resources instead of multiple arguments in init. Now it is sufficient to create a resource file "name_of_entity".tres and plug that into the init of entity (_init("name_of_entity")). 